### PR TITLE
Patch for Foundation on Android 8.1 (27) and lower

### DIFF
--- a/Patches/swift-corelibs-foundation/Sources/Foundation/Process.swift.diff
+++ b/Patches/swift-corelibs-foundation/Sources/Foundation/Process.swift.diff
@@ -1,0 +1,37 @@
+diff --git a/Sources/Foundation/Process.swift b/Sources/Foundation/Process.swift
+index 21615c19..4734e1bd 100644
+--- a/Sources/Foundation/Process.swift
++++ b/Sources/Foundation/Process.swift
+@@ -944,14 +944,10 @@ open class Process: NSObject {
+             try _throwIfPosixError(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
+         }
+ 
+-#if canImport(Darwin) || os(Android)
++#if canImport(Darwin)
+         var spawnAttrs: posix_spawnattr_t? = nil
+-#else
+-        var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
+-#endif
+         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
+         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
+-#if canImport(Darwin)
+         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT)))
+ #else
+         // POSIX_SPAWN_CLOEXEC_DEFAULT is an Apple extension so emulate it.
+@@ -978,10 +974,16 @@ open class Process: NSObject {
+ 
+         // Launch
+         var pid = pid_t()
++#if os(macOS)
+         guard _CFPosixSpawn(&pid, launchPath, fileActions, &spawnAttrs, argv, envp) == 0 else {
+             throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
+         }
+         posix_spawnattr_destroy(&spawnAttrs)
++#else
++        guard _CFPosixSpawn(&pid, launchPath, fileActions, nil, argv, envp) == 0 else {
++            throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
++        }
++#endif
+ 
+         // Close the write end of the input and output pipes.
+         if let pipe = standardInput as? Pipe {

--- a/lib/Builders/FoundationBuilder.js
+++ b/lib/Builders/FoundationBuilder.js
@@ -110,6 +110,7 @@ module.exports = class FoundationBuilder extends Builder {
   configurePatches(/** @type {Boolean} */ shouldEnable) {
     this.configurePatch(`${this.paths.patches}/Sources/CMakeLists.txt.diff`, shouldEnable)
     this.configurePatch(`${this.paths.patches}/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h.diff`, shouldEnable)
+    this.configurePatch(`${this.paths.patches}/Sources/Foundation/Process.swift.diff`, shouldEnable)
   }
 
   executeBuild() {


### PR DESCRIPTION
I received a [response](https://forums.swift.org/t/posix-spawnattr-init-on-android-8-1-and-earlier/48106) in the Swift forums about the Swift 5.4/Android 8.1 incompatibility issue.

The recommendation was to either link with a backported version of the official posix_spawn wrapper or revert [PR-2928](https://github.com/apple/swift-corelibs-foundation/pull/2928) and [PR-2942](https://github.com/apple/swift-corelibs-foundation/pull/2942).

Since this change was added for Linux scripting, I added a patch to just revert the change.