### PR TITLE
Simplify install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,57 +27,33 @@ Build of complete toolchain takes ~1.5h. Instead of building it you can just dow
 
 ## Setup and Build
 
-1. Check that CMake is installed. Install CMake if needed.
+1. Install CMake, Ninja, Autotools and git-lfs. Check that all requirements are installed.
 
    ```bash
+   brew install cmake ninja autoconf automake libtool pkg-config git-lfs
    which cmake
-   brew install cmake
-   ```
-
-2. Check that Ninja is installed. Install Ninja if needed.
-
-   ```bash
    which ninja
-   brew install ninja
-   ```
-
-3. Check that Autotools is installed. Install Autotools if needed.
-
-   ```bash
    which autoconf
-   brew install autoconf
-
    which aclocal
-   brew install automake
-
    which glibtool
-   brew install libtool
-
    which pkg-config
-   brew install pkg-config
-   ```
-
-4. Check that git-lfs is installed. Install git-lfs if needed.
-
-   ```bash
    which git-lfs
-   brew install git-lfs
    ```
 
-5. Make sure that `Xcode Build Tools` properly configured.
+2. Make sure that `Xcode Build Tools` properly configured.
 
    ```bash
    xcode-select --print-path
    ```
 
-6. Clone this repository.
+3. Clone this repository.
 
    ```bash
    git clone https://github.com/vgorloff/swift-everywhere-toolchain.git
    cd swift-everywhere-toolchain
    ```
 
-7. Create a symbolic link to NDK installation directory.
+4. Create a symbolic link to NDK installation directory.
 
    ```bash
    sudo mkdir -p /usr/local/ndk
@@ -86,13 +62,13 @@ Build of complete toolchain takes ~1.5h. Instead of building it you can just dow
 
    The placeholder `$VERSION` needs to be replaced with a version mentioned in file `NDK_VERSION` at the root of cloned repository.
 
-8. Start a build.
+5. Start a build.
 
    ```bash
    node main.js
    ```
 
-9. Once the build completed, toolchain will be saved to folder `ToolChain/swift-android-toolchain` and compressed into archive `ToolChain/swift-android-toolchain.tar.gz`.
+6. Once the build completed, toolchain will be saved to folder `ToolChain/swift-android-toolchain` and compressed into archive `ToolChain/swift-android-toolchain.tar.gz`.
 
 ## Usage
 


### PR DESCRIPTION
The install instructions look more complicated than they actually are.
By merging all `brew` commands into a single command, it is possible to verify that all homebrew requirements are installed using a single copy&paste operation.
Also, this change reduces the number of install instructions steps from 9 to 6.